### PR TITLE
fix: add a small value 1e-9 to denominators to prevent division by ze…

### DIFF
--- a/run_classifier.py
+++ b/run_classifier.py
@@ -218,13 +218,16 @@ def evaluate(args, dataset, print_confusion_matrix=False):
         correct += torch.sum(pred == gold).item()
 
     if print_confusion_matrix:
+        eps = 1e-9
         print("Confusion matrix:")
         print(confusion)
         print("Report precision, recall, and f1:")
+        
+        # add a small value 1e-9 to denominators to prevent division by zero
         for i in range(confusion.size()[0]):
-            p = confusion[i, i].item() / confusion[i, :].sum().item()
-            r = confusion[i, i].item() / confusion[:, i].sum().item()
-            f1 = 2 * p * r / (p + r)
+            p = confusion[i, i].item() / (confusion[i, :].sum().item() + eps)
+            r = confusion[i, i].item() / (confusion[:, i].sum().item() + eps)
+            f1 = 2 * p * r / (p + r + eps)
             print("Label {}: {:.3f}, {:.3f}, {:.3f}".format(i, p, r, f1))
 
     print("Acc. (Correct/Total): {:.4f} ({}/{}) ".format(correct / len(dataset), correct, len(dataset)))


### PR DESCRIPTION
修复：在run_classifier的混淆矩阵计算中，为p、r、f1计算式的分母中添加一个极小值1e-9，避免除零错误
fix: add a small value 1e-9 to denominators to prevent division by zero when calculating confusion matrix
