### PR TITLE
add support for Deepspeed https://github.com/microsoft/DeepSpeed

### DIFF
--- a/models/deepspeed_config.json
+++ b/models/deepspeed_config.json
@@ -1,0 +1,42 @@
+{
+  "gradient_accumulation_steps": 1,
+  "train_micro_batch_size_per_gpu":1,
+  "steps_per_print": 100,
+  "optimizer": {
+    "type": "Adam",
+    "params": {
+      "lr": 0.00001,
+      "weight_decay": 1e-2
+    }
+  },
+  "flops_profiler": {
+    "enabled": true,
+    "profile_step": 1,
+    "module_depth": -1,
+    "top_modules": 3,
+    "detailed": true
+  },
+  "fp16": {
+    "enabled": true,
+    "loss_scale": 0,
+    "loss_scale_window": 1000,
+    "hysteresis": 2,
+    "min_loss_scale": 1
+  },
+  "zero_optimization": {
+      "stage": 2,
+      "cpu_offload": true,
+      "contiguous_gradients": false,
+      "overlap_comm": false,
+      "reduce_scatter": false,
+      "reduce_bucket_size": 5e7,
+      "allgather_bucket_size": 5e7
+  },
+  "activation_checkpointing": {
+      "partition_activations": false,
+      "contiguous_memory_optimization": false,
+      "cpu_checkpointing": false
+  },
+  "wall_clock_breakdown": false,
+  "zero_allow_untested_optimizer": true
+}

--- a/pretrain.py
+++ b/pretrain.py
@@ -90,6 +90,9 @@ def main():
     parser.add_argument("--master_ip", default="tcp://localhost:12345", type=str, help="IP-Port of master for training.")
     parser.add_argument("--backend", choices=["nccl", "gloo"], default="nccl", type=str, help="Distributed backend.")
 
+    # Deepspeed options.
+    deepspeed_opts(parser)
+
     args = parser.parse_args()
 
     if args.target == "cls":
@@ -101,28 +104,36 @@ def main():
 
     ranks_num = len(args.gpu_ranks)
 
-    if args.world_size > 1:
-        # Multiprocessing distributed mode.
-        assert torch.cuda.is_available(), "No available GPUs."
-        assert ranks_num <= args.world_size, "Started processes exceed `world_size` upper limit."
-        assert ranks_num <= torch.cuda.device_count(), "Started processes exceeds the available GPUs."
-        args.dist_train = True
-        args.ranks_num = ranks_num
-        print("Using distributed mode for training.")
-    elif args.world_size == 1 and ranks_num == 1:
-        # Single GPU mode.
-        assert torch.cuda.is_available(), "No available GPUs."
-        args.gpu_id = args.gpu_ranks[0]
-        assert args.gpu_id < torch.cuda.device_count(), "Invalid specified GPU device."
-        args.dist_train = False
-        args.single_gpu = True
-        print("Using GPU %d for training." % args.gpu_id)
+    if args.deepspeed:
+        if args.world_size > 1:
+            args.dist_train = True
+            print("Using distributed mode for training.")
+        else:
+            args.dist_train = False
+            print("Using single GPU for training.")
     else:
-        # CPU mode.
-        assert ranks_num == 0, "GPUs are specified, please check the arguments."
-        args.dist_train = False
-        args.single_gpu = False
-        print("Using CPU mode for training.")
+        if args.world_size > 1:
+            # Multiprocessing distributed mode.
+            assert torch.cuda.is_available(), "No available GPUs."
+            assert ranks_num <= args.world_size, "Started processes exceed `world_size` upper limit."
+            assert ranks_num <= torch.cuda.device_count(), "Started processes exceeds the available GPUs."
+            args.dist_train = True
+            args.ranks_num = ranks_num
+            print("Using distributed mode for training.")
+        elif args.world_size == 1 and ranks_num == 1:
+            # Single GPU mode.
+            assert torch.cuda.is_available(), "No available GPUs."
+            args.gpu_id = args.gpu_ranks[0]
+            assert args.gpu_id < torch.cuda.device_count(), "Invalid specified GPU device."
+            args.dist_train = False
+            args.single_gpu = True
+            print("Using GPU %d for training." % args.gpu_id)
+        else:
+            # CPU mode.
+            assert ranks_num == 0, "GPUs are specified, please check the arguments."
+            args.dist_train = False
+            args.single_gpu = False
+            print("Using CPU mode for training.")
 
     trainer.train_and_validate(args)
 

--- a/uer/opts.py
+++ b/uer/opts.py
@@ -126,3 +126,11 @@ def tokenizer_opts(parser):
                              "Space tokenizer segments sentences into words according to space."
                              "Original XLM-RoBERTa uses xlmroberta tokenizer."
                              )
+
+
+def deepspeed_opts(parser):
+    parser.add_argument("--deepspeed", action="store_true",
+                        help=".")
+    parser.add_argument("--deepspeed_config", default="models/deepspeed_config.json", type=str,
+                        help=".")
+    parser.add_argument("--local_rank", type=int, required=False)

--- a/uer/trainer.py
+++ b/uer/trainer.py
@@ -408,14 +408,15 @@ def worker(proc_id, gpu_ranks, args, model):
     if args.optimizer in ["adamw"]:
         custom_optimizer = str2optimizer[args.optimizer](optimizer_grouped_parameters, lr=args.learning_rate, correct_bias=False)
     else:
-        custom_optimizer = str2optimizer[args.optimizer](optimizer_grouped_parameters, lr=args.learning_rate, scale_parameter=False, relative_step=False)
+        custom_optimizer = str2optimizer[args.optimizer](optimizer_grouped_parameters, lr=args.learning_rate,
+                                                         scale_parameter=False, relative_step=False)
 
     if args.scheduler in ["constant"]:
         custom_scheduler = str2scheduler[args.scheduler](custom_optimizer)
     elif args.scheduler in ["constant_with_warmup"]:
-        custom_scheduler = str2scheduler[args.scheduler](custom_optimizer, args.total_steps * args.warmup)
+        custom_scheduler = str2scheduler[args.scheduler](custom_optimizer, args.total_steps*args.warmup)
     else:
-        custom_scheduler = str2scheduler[args.scheduler](custom_optimizer, args.total_steps * args.warmup, args.total_steps)
+        custom_scheduler = str2scheduler[args.scheduler](custom_optimizer, args.total_steps*args.warmup, args.total_steps)
 
     if args.deepspeed:
         optimizer = None

--- a/uer/utils/config.py
+++ b/uer/utils/config.py
@@ -10,4 +10,8 @@ def load_hyperparam(args):
     args_dict.update(param)
     args = Namespace(**args_dict)
 
+    if "deepspeed" in args.__dict__:
+        with open(args.deepspeed_config, mode="r", encoding="utf-8") as f:
+            args.deepspeed_config_param = json.load(f)
+
     return args


### PR DESCRIPTION
本项目新增支持使用Deepspeed进行大规模模型预训练，有关Deepspeed的介绍与详细细节请参考https://github.com/microsoft/DeepSpeed
Deepspeed支持使用单机和多机进行模型训练，以训练gpt2-xlarge为例
使用单机八卡进行训练：
```
deepspeed pretrain.py --deepspeed --deepspeed_config models/deepspeed_config.json \
                      --dataset_path cluecorpussmall_lm_seq128_dataset.pt \
                      --vocab_path models/google_zh_vocab.txt --output_model_path gpt2_xlarge \
                      --world_size 8 --total_steps 500000 --save_checkpoint_steps 50000 \
                      --embedding word_pos --remove_embedding_layernorm --encoder transformer \
                      --deep_init --mask causal --layernorm_positioning pre --target lm --tie_weights \
                      --batch_size 32 --config_path models/gpt2/xlarge_config.json --report_steps 100
```
使用多机训练时需要先配置hostfile.txt文件，文件格式为：ip slots=gpu数
例如：
1.1.1.1 slots=8
2.2.2.2 slots=8
使用两机八卡进行训练：
```
deepspeed --hostfile=hostfile.txt pretrain.py --deepspeed --deepspeed_config models/deepspeed_config.json \
                                              --dataset_path cluecorpussmall_lm_seq128_dataset.pt \
                                              --vocab_path models/google_zh_vocab.txt --output_model_path gpt2_xlarge \
                                              --world_size 16 --total_steps 500000 --save_checkpoint_steps 50000 \
                                              --embedding word_pos --remove_embedding_layernorm --encoder transformer \
                                              --deep_init --mask causal --layernorm_positioning pre --target lm --tie_weights \
                                              --batch_size 32 --config_path models/gpt2/xlarge_config.json --report_steps 100
```
