### PR TITLE
add support for Deepspeed https://github.com/microsoft/DeepSpeed

### DIFF
--- a/models/deepspeed_config.json
+++ b/models/deepspeed_config.json
@@ -1,0 +1,42 @@
+{
+  "gradient_accumulation_steps": 1,
+  "train_micro_batch_size_per_gpu":1,
+  "steps_per_print": 100,
+  "optimizer": {
+    "type": "Adam",
+    "params": {
+      "lr": 0.00001,
+      "weight_decay": 1e-2
+    }
+  },
+  "flops_profiler": {
+    "enabled": true,
+    "profile_step": 1,
+    "module_depth": -1,
+    "top_modules": 3,
+    "detailed": true
+  },
+  "fp16": {
+    "enabled": true,
+    "loss_scale": 0,
+    "loss_scale_window": 1000,
+    "hysteresis": 2,
+    "min_loss_scale": 1
+  },
+  "zero_optimization": {
+      "stage": 2,
+      "cpu_offload": true,
+      "contiguous_gradients": false,
+      "overlap_comm": false,
+      "reduce_scatter": false,
+      "reduce_bucket_size": 5e7,
+      "allgather_bucket_size": 5e7
+  },
+  "activation_checkpointing": {
+      "partition_activations": false,
+      "contiguous_memory_optimization": false,
+      "cpu_checkpointing": false
+  },
+  "wall_clock_breakdown": false,
+  "zero_allow_untested_optimizer": true
+}

--- a/pretrain.py
+++ b/pretrain.py
@@ -75,6 +75,9 @@ def main():
     parser.add_argument("--master_ip", default="tcp://localhost:12345", type=str, help="IP-Port of master for training.")
     parser.add_argument("--backend", choices=["nccl", "gloo"], default="nccl", type=str, help="Distributed backend.")
 
+    # Deepspeed options.
+    deepspeed_opts(parser)
+
     args = parser.parse_args()
 
     if args.target == "cls":
@@ -86,28 +89,36 @@ def main():
 
     ranks_num = len(args.gpu_ranks)
 
-    if args.world_size > 1:
-        # Multiprocessing distributed mode.
-        assert torch.cuda.is_available(), "No available GPUs."
-        assert ranks_num <= args.world_size, "Started processes exceed `world_size` upper limit."
-        assert ranks_num <= torch.cuda.device_count(), "Started processes exceeds the available GPUs."
-        args.dist_train = True
-        args.ranks_num = ranks_num
-        print("Using distributed mode for training.")
-    elif args.world_size == 1 and ranks_num == 1:
-        # Single GPU mode.
-        assert torch.cuda.is_available(), "No available GPUs."
-        args.gpu_id = args.gpu_ranks[0]
-        assert args.gpu_id < torch.cuda.device_count(), "Invalid specified GPU device."
-        args.dist_train = False
-        args.single_gpu = True
-        print("Using GPU %d for training." % args.gpu_id)
+    if args.deepspeed:
+        if args.world_size > 1:
+            args.dist_train = True
+            print("Using distributed mode for training.")
+        else:
+            args.dist_train = False
+            print("Using single GPU for training.")
     else:
-        # CPU mode.
-        assert ranks_num == 0, "GPUs are specified, please check the arguments."
-        args.dist_train = False
-        args.single_gpu = False
-        print("Using CPU mode for training.")
+        if args.world_size > 1:
+            # Multiprocessing distributed mode.
+            assert torch.cuda.is_available(), "No available GPUs."
+            assert ranks_num <= args.world_size, "Started processes exceed `world_size` upper limit."
+            assert ranks_num <= torch.cuda.device_count(), "Started processes exceeds the available GPUs."
+            args.dist_train = True
+            args.ranks_num = ranks_num
+            print("Using distributed mode for training.")
+        elif args.world_size == 1 and ranks_num == 1:
+            # Single GPU mode.
+            assert torch.cuda.is_available(), "No available GPUs."
+            args.gpu_id = args.gpu_ranks[0]
+            assert args.gpu_id < torch.cuda.device_count(), "Invalid specified GPU device."
+            args.dist_train = False
+            args.single_gpu = True
+            print("Using GPU %d for training." % args.gpu_id)
+        else:
+            # CPU mode.
+            assert ranks_num == 0, "GPUs are specified, please check the arguments."
+            args.dist_train = False
+            args.single_gpu = False
+            print("Using CPU mode for training.")
 
     trainer.train_and_validate(args)
 

--- a/uer/opts.py
+++ b/uer/opts.py
@@ -131,3 +131,11 @@ def tgt_tokenizer_opts(parser):
                         help="Path of the target vocabulary file.")
     parser.add_argument("--tgt_spm_model_path", default=None, type=str,
                         help="Path of the target sentence piece model.")
+
+
+def deepspeed_opts(parser):
+    parser.add_argument("--deepspeed", action="store_true",
+                        help=".")
+    parser.add_argument("--deepspeed_config", default="models/deepspeed_config.json", type=str,
+                        help=".")
+    parser.add_argument("--local_rank", type=int, required=False)

--- a/uer/trainer.py
+++ b/uer/trainer.py
@@ -47,7 +47,9 @@ def train_and_validate(args):
                 if "gamma" not in n and "beta" not in n:
                     p.data.normal_(0, 0.02)
 
-    if args.dist_train:
+    if args.deepspeed:
+        worker(args.local_rank, None, args, model)
+    elif args.dist_train:
         # Multiprocessing distributed mode.
         mp.spawn(worker, nprocs=args.ranks_num, args=(args.gpu_ranks, args, model), daemon=False)
     elif args.single_gpu:
@@ -97,25 +99,35 @@ class Trainer(object):
 
             loss = self.forward_propagation(batch, model)
 
-            if args.fp16:
-                with args.amp.scale_loss(loss, optimizer) as scaled_loss:
-                    scaled_loss.backward()
+            if args.deepspeed:
+                model.backward(loss)
             else:
-                loss.backward()
+                if args.fp16:
+                    with args.amp.scale_loss(loss, optimizer) as scaled_loss:
+                        scaled_loss.backward()
+                else:
+                    loss.backward()
 
             if self.current_step % self.accumulation_steps == 0:
-                optimizer.step()
-                scheduler.step()
-                model.zero_grad()
+                if args.deepspeed:
+                    model.step()
+                else:
+                    optimizer.step()
+                    scheduler.step()
+                    model.zero_grad()
 
             if self.current_step % self.report_steps == 0 and \
                     (not self.dist_train or (self.dist_train and rank == 0)):
                 self.report_and_reset_stats()
                 self.start_time = time.time()
 
-            if self.current_step % self.save_checkpoint_steps == 0 and \
-                    (not self.dist_train or (self.dist_train and rank == 0)):
-                save_model(model, self.output_model_path + "-" + str(self.current_step))
+            if args.deepspeed:
+                if self.current_step % self.save_checkpoint_steps == 0:
+                    model.save_checkpoint(self.output_model_path, str(self.current_step))
+            else:
+                if self.current_step % self.save_checkpoint_steps == 0 and \
+                        (not self.dist_train or (self.dist_train and rank == 0)):
+                    save_model(model, self.output_model_path + "-" + str(self.current_step))
 
             self.current_step += 1
 
@@ -365,7 +377,12 @@ def worker(proc_id, gpu_ranks, args, model):
     """
     set_seed(args.seed)
 
-    if args.dist_train:
+    if args.deepspeed:
+        import deepspeed
+        deepspeed.init_distributed(dist_backend=args.backend)
+        rank = dist.get_rank()
+        gpu_id = proc_id
+    elif args.dist_train:
         rank = gpu_ranks[proc_id]
         gpu_id = proc_id
     elif args.single_gpu:
@@ -387,39 +404,63 @@ def worker(proc_id, gpu_ranks, args, model):
         {"params": [p for n, p in param_optimizer if not any(nd in n for nd in no_decay)], "weight_decay": 0.01},
         {"params": [p for n, p in param_optimizer if any(nd in n for nd in no_decay)], "weight_decay": 0.0}
     ]
+
     if args.optimizer in ["adamw"]:
-        optimizer = str2optimizer[args.optimizer](optimizer_grouped_parameters, lr=args.learning_rate, correct_bias=False)
+        custom_optimizer = str2optimizer[args.optimizer](optimizer_grouped_parameters, lr=args.learning_rate, correct_bias=False)
     else:
-        optimizer = str2optimizer[args.optimizer](optimizer_grouped_parameters, lr=args.learning_rate,
-                                                  scale_parameter=False, relative_step=False)
+        custom_optimizer = str2optimizer[args.optimizer](optimizer_grouped_parameters, lr=args.learning_rate, scale_parameter=False, relative_step=False)
     if args.scheduler in ["constant"]:
-        scheduler = str2scheduler[args.scheduler](optimizer)
+        custom_scheduler = str2scheduler[args.scheduler](custom_optimizer)
     elif args.scheduler in ["constant_with_warmup"]:
-        scheduler = str2scheduler[args.scheduler](optimizer, args.total_steps*args.warmup)
+        custom_scheduler = str2scheduler[args.scheduler](custom_optimizer, args.total_steps*args.warmup)
     else:
-        scheduler = str2scheduler[args.scheduler](optimizer, args.total_steps*args.warmup, args.total_steps)
+        custom_scheduler = str2scheduler[args.scheduler](custom_optimizer, args.total_steps*args.warmup, args.total_steps)
 
-    if gpu_id is not None:
-        model.cuda(gpu_id)
+    if args.deepspeed:
+        optimizer = None
+        scheduler = None
 
-    if args.fp16:
-        try:
-            from apex import amp
-        except ImportError:
-            raise ImportError("Please install apex from https://www.github.com/nvidia/apex to use fp16 training.")
-        model, optimizer = amp.initialize(model, optimizer, opt_level=args.fp16_opt_level)
-        args.amp = amp
-
-    if args.dist_train:
-        # Initialize multiprocessing distributed training environment.
-        dist.init_process_group(backend=args.backend,
-                                init_method=args.master_ip,
-                                world_size=args.world_size,
-                                rank=rank)
-        model = DistributedDataParallel(model, device_ids=[gpu_id], find_unused_parameters=True)
-        print("Worker %d is training ... " % rank)
+        # IF User NOT defined optimezer in deepspeed config,
+        # Then use Self Defined Optimizer
+        if "optimizer" not in args.deepspeed_config_param:
+            optimizer = custom_optimizer
+            if args.local_rank == 0:
+                print("Use Custum Optimizer", optimizer)
+        if "scheduler" not in args.deepspeed_config_param:
+            scheduler = custom_scheduler
+            if args.local_rank == 0:
+                print("Use Custom LR Schedule", scheduler)
+        model, optimizer, _, scheduler = deepspeed.initialize(
+                                                    model=model,
+                                                    model_parameters=optimizer_grouped_parameters,
+                                                    args=args,
+                                                    optimizer=optimizer,
+                                                    lr_scheduler=scheduler,
+                                                    mpu=None,
+                                                    dist_init_required=False)
     else:
-        print("Worker is training ...")
+        if gpu_id is not None:
+            model.cuda(gpu_id)
+        optimizer = custom_optimizer
+        scheduler = custom_scheduler
+        if args.fp16:
+            try:
+                from apex import amp
+            except ImportError:
+                raise ImportError("Please install apex from https://www.github.com/nvidia/apex to use fp16 training.")
+            model, optimizer = amp.initialize(model, optimizer, opt_level=args.fp16_opt_level)
+            args.amp = amp
+
+        if args.dist_train:
+            # Initialize multiprocessing distributed training environment.
+            dist.init_process_group(backend=args.backend,
+                                    init_method=args.master_ip,
+                                    world_size=args.world_size,
+                                    rank=rank)
+            model = DistributedDataParallel(model, device_ids=[gpu_id], find_unused_parameters=True)
+            print("Worker %d is training ... " % rank)
+        else:
+            print("Worker is training ...")
 
     trainer = str2trainer[args.target](args)
     trainer.train(args, gpu_id, rank, train_loader, model, optimizer, scheduler)

--- a/uer/utils/config.py
+++ b/uer/utils/config.py
@@ -6,6 +6,10 @@ def load_hyperparam(args):
     with open(args.config_path, mode="r", encoding="utf-8") as f:
         param = json.load(f)
 
+    if "deepspeed" in args.__dict__:
+        with open(args.deepspeed_config, mode="r", encoding="utf-8") as f:
+            args.deepspeed_config_param = json.load(f)
+
     args_dict = vars(args)
     args_dict.update(param)
     args = Namespace(**args_dict)


### PR DESCRIPTION
本项目新增支持使用Deepspeed进行大规模模型预训练，有关Deepspeed的介绍与详细细节请参考https://github.com/microsoft/DeepSpeed
Deepspeed支持使用单机和多机进行模型训练，以训练gpt2-xlarge为例
使用单机八卡进行训练：
```
deepspeed pretrain.py --deepspeed --deepspeed_config models/deepspeed_config.json \
                      --dataset_path cluecorpussmall_lm_seq128_dataset.pt \
                      --vocab_path models/google_zh_vocab.txt --output_model_path gpt2_xlarge \
                      --world_size 8 --total_steps 500000 --save_checkpoint_steps 50000 \
                      --embedding word_pos --remove_embedding_layernorm --encoder transformer \
                      --deep_init --mask causal --layernorm_positioning pre --target lm --tie_weights \
                      --batch_size 32 --config_path models/gpt2/xlarge_config.json --report_steps 100
```
使用多机训练时需要先配置hostfile.txt文件，文件格式为：ip slots=gpu数
例如：
1.1.1.1 slots=8
2.2.2.2 slots=8
使用两机八卡进行训练：
```
deepspeed --hostfile=hostfile.txt pretrain.py --deepspeed --deepspeed_config models/deepspeed_config.json \
                                              --dataset_path cluecorpussmall_lm_seq128_dataset.pt \
                                              --vocab_path models/google_zh_vocab.txt --output_model_path gpt2_xlarge \
                                              --world_size 16 --total_steps 500000 --save_checkpoint_steps 50000 \
                                              --embedding word_pos --remove_embedding_layernorm --encoder transformer \
                                              --deep_init --mask causal --layernorm_positioning pre --target lm --tie_weights \
                                              --batch_size 32 --config_path models/gpt2/xlarge_config.json --report_steps 100
```
注意，使用deepspeed进行模型训练时，除batach size相关参数外（目前本项目的batach size不支持通过deepspeed配置），其他deepspeed相关参数通过deepspeed_config.json文件进行配置，有关deepspeed配置详细信息请参考https://www.deepspeed.ai/docs/config-json/