### PR TITLE
Fixed a bug for whole word masking

### DIFF
--- a/uer/utils/mask.py
+++ b/uer/utils/mask.py
@@ -27,14 +27,16 @@ def mask_seq(src, tokenizer, whole_word_masking, span_masking, span_geo_prob, sp
             mask_len = index_set[1]
             if len(tgt_mlm) + mask_len > num_to_predict:
                 continue
-
-            for j in range(mask_len):
-                token = src[i + j]
-                tgt_mlm.append((i + j, token))
-                prob = random.random()
-                if prob < 0.8:
+            prob = random.random()
+            if prob < 0.8:
+                for j in range(mask_len):
+                    token = src[i + j]
+                    tgt_mlm.append((i + j, token))                
                     src[i + j] = vocab.get(MASK_TOKEN)
-                elif prob < 0.9:
+            elif prob < 0.9:
+                for j in range(mask_len):
+                    token = src[i + j]
+                    tgt_mlm.append((i + j, token))                
                     while True:
                         rdi = random.randint(1, len(vocab) - 1)
                         if rdi not in [vocab.get(CLS_TOKEN), vocab.get(SEP_TOKEN), vocab.get(MASK_TOKEN), PAD_ID]:


### PR DESCRIPTION
Hi，nice work. 
And I found a bug when using your repository.

For the original wwm policy, the implementation is to first iterate through each word inside a phrase, and then use a mask token to replace the original token for some words and a random token for others based on the probability. This implementation results in inconsistent replacement rules for each word inside a phrase. The correct way to experiment would be to first determine the probability and then iterate through each word within the phrase. This ensures that the substitution rule is consistent for each word within a phrase.

:)

---
你好，很棒的工作。
唯一一个问题是我在使用你们的仓库时发现了一个小bug。

针对whole word masking策略，你们的仓库实现方式为首先遍历一个词组内部的每一个字，生成概率决定有的字使用mask token替换原始token，有的字使用随机替换原始token。这种实现方式会导致一个词组内部的每一个字替换法则不一致。正确的实验方式应该为首先确定概率，之后遍历词组内部的每一个字。这样可确保一个词组内部的每一个字替换法则一致。