### PR TITLE
Possible typo. models/gpt2/config.json

### DIFF
--- a/models/gpt2/config.json
+++ b/models/gpt2/config.json
@@ -13,6 +13,6 @@
   "encoder": "transformer",
   "mask": "causal",
   "layernorm_positioning": "pre",
-  "target": ["lm"],
+  "target": "lm",
   "tie_weights": true
 }


### PR DESCRIPTION
cause: "target": ["lm"], will cause hashing error when executing scripts/generate_lm.py line 29
correction: removed [] -> "target": "lm",