### PR TITLE
argument typo in opts.py

### DIFF
--- a/uer/opts.py
+++ b/uer/opts.py
@@ -46,10 +46,10 @@ def model_opts(parser):
 def log_opts(parser):
     parser.add_argument("--log_path", type=str, default=None,
                         help="Log file path, default no output file.")
-    parser.add_argument("--log_level", choices=["ERROR", "INFO", "DEBUG", "NOSET"], default="INFO",
-                        help="Console log level. Verbosity: ERROR < INFO < DEBUG < NOSET")
-    parser.add_argument("--log_file_level", choices=["ERROR", "INFO", "DEBUG", "NOSET"], default="INFO",
-                        help="Log file level. Verbosity: ERROR < INFO < DEBUG < NOSET")
+    parser.add_argument("--log_level", choices=["ERROR", "INFO", "DEBUG", "NOTSET"], default="INFO",
+                        help="Console log level. Verbosity: ERROR < INFO < DEBUG < NOTSET")
+    parser.add_argument("--log_file_level", choices=["ERROR", "INFO", "DEBUG", "NOTSET"], default="INFO",
+                        help="Log file level. Verbosity: ERROR < INFO < DEBUG < NOTSET")
 
 
 def optimization_opts(parser):


### PR DESCRIPTION
mismatched argument name: --log_level and --log_file_level with python/Lib/logging/__init__.py, should be 'NOTSET', not 'NOSET'
action: all occurrences changed from 'NOSET' to 'NOTSET'